### PR TITLE
Support CocoaPods 1.x for KaeruDemo.

### DIFF
--- a/KaeruDemo/Podfile
+++ b/KaeruDemo/Podfile
@@ -1,3 +1,6 @@
 platform :ios, "9.0"
-pod 'Kaeru', :path => '../'
 use_frameworks!
+
+target 'KaeruDemo' do
+  pod 'Kaeru', :path => '../'
+end


### PR DESCRIPTION
Resolve an error when `pod install` using CocoaPods 1.x.

```
[!] The dependency `Kaeru (from `../`)` is not used in any concrete target.
```
